### PR TITLE
A TiffException is thrown on unknown field tag and type values.

### DIFF
--- a/src/main/java/mil/nga/tiff/FieldTagType.java
+++ b/src/main/java/mil/nga/tiff/FieldTagType.java
@@ -156,6 +156,26 @@ public enum FieldTagType {
 
 	YPosition(287, false),
 
+	// JPEG
+
+	JPEGProc(512, false),
+
+	JPEGInterchangeFormat(513, false),
+
+	JPEGInterchangeFormatLength(514, false),
+
+	JPEGRestartInterval(515, false),
+
+	JPEGLosslessPredictors(517, true),
+
+	JPEGPointTransforms(518, true),
+
+	JPEGQTables(519, true),
+
+	JPEGDCTables(520, true),
+
+	JPEGACTables(521, true),
+
 	// EXIF
 
 	ApertureValue(37378, false),

--- a/src/main/java/mil/nga/tiff/FileDirectory.java
+++ b/src/main/java/mil/nga/tiff/FileDirectory.java
@@ -15,6 +15,7 @@ import mil.nga.tiff.compression.DeflateCompression;
 import mil.nga.tiff.compression.LZWCompression;
 import mil.nga.tiff.compression.PackbitsCompression;
 import mil.nga.tiff.compression.RawCompression;
+import mil.nga.tiff.compression.UnsupportedCompression;
 import mil.nga.tiff.io.ByteReader;
 import mil.nga.tiff.util.TiffConstants;
 import mil.nga.tiff.util.TiffException;
@@ -136,21 +137,24 @@ public class FileDirectory {
 			decoder = new RawCompression();
 			break;
 		case TiffConstants.COMPRESSION_CCITT_HUFFMAN:
-			throw new TiffException("CCITT Huffman compression not supported: "
+			decoder = new UnsupportedCompression("CCITT Huffman compression not supported: "
 					+ compression);
+			break;
 		case TiffConstants.COMPRESSION_T4:
-			throw new TiffException("T4-encoding compression not supported: "
+			decoder = new UnsupportedCompression("T4-encoding compression not supported: "
 					+ compression);
 		case TiffConstants.COMPRESSION_T6:
-			throw new TiffException("T6-encoding compression not supported: "
+			decoder = new UnsupportedCompression("T6-encoding compression not supported: "
 					+ compression);
+			break;
 		case TiffConstants.COMPRESSION_LZW:
 			decoder = new LZWCompression();
 			break;
 		case TiffConstants.COMPRESSION_JPEG_OLD:
 		case TiffConstants.COMPRESSION_JPEG_NEW:
-			throw new TiffException("JPEG compression not supported: "
+			decoder = new UnsupportedCompression("JPEG compression not supported: "
 					+ compression);
+			break;
 		case TiffConstants.COMPRESSION_DEFLATE:
 		case TiffConstants.COMPRESSION_PKZIP_DEFLATE:
 			decoder = new DeflateCompression();
@@ -159,7 +163,7 @@ public class FileDirectory {
 			decoder = new PackbitsCompression();
 			break;
 		default:
-			throw new TiffException("Unknown compression method identifier: "
+			decoder = new UnsupportedCompression("Unknown compression method identifier: "
 					+ compression);
 		}
 	}

--- a/src/main/java/mil/nga/tiff/TiffReader.java
+++ b/src/main/java/mil/nga/tiff/TiffReader.java
@@ -200,8 +200,16 @@ public class TiffReader {
 				// Read the field tag, field type, and type count
 				int fieldTagValue = reader.readUnsignedShort();
 				FieldTagType fieldTag = FieldTagType.getById(fieldTagValue);
+				if (fieldTag == null) {
+					throw new TiffException("Unknown field tag value " + fieldTagValue);
+				}
+
 				int fieldTypeValue = reader.readUnsignedShort();
 				FieldType fieldType = FieldType.getFieldType(fieldTypeValue);
+				if (fieldType == null) {
+					throw new TiffException("Unknown field type value " + fieldTypeValue);
+				}
+
 				long typeCount = reader.readUnsignedInt();
 
 				// Save off the next byte to read location

--- a/src/main/java/mil/nga/tiff/compression/UnsupportedCompression.java
+++ b/src/main/java/mil/nga/tiff/compression/UnsupportedCompression.java
@@ -1,0 +1,50 @@
+package mil.nga.tiff.compression;
+
+import java.nio.ByteOrder;
+
+import mil.nga.tiff.util.TiffException;
+
+/**
+ * Unsupported compression
+ * 
+ * @author michaelknigge
+ */
+public class UnsupportedCompression implements CompressionDecoder, CompressionEncoder {
+
+	private final String message;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param message
+	 *            message of the TiffException
+	 * @since 2.0.1
+	 */
+	public UnsupportedCompression(final String message) {
+		this.message = message;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public byte[] decode(byte[] bytes, ByteOrder byteOrder) {
+		throw new TiffException(this.message);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean rowEncoding() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public byte[] encode(byte[] bytes, ByteOrder byteOrder) {
+		throw new TiffException(this.message);
+	}
+}


### PR DESCRIPTION
If an unknown field type value is encountered a TiffException will be thrown immediately. The exception message contains the unknown value. This gives the user a better feedback. If the exception wouldn't be thrown, a NullPointerException would occur just a few lines later (when invoking readFieldValues and i. e. null is given for fieldTag). 

Now, when reading a TIFF file and an unsupported compression method is used, a TiffException is thrown only if the caller tries to decompress the image. That allows users of the TIFF-Library just to parse the tiff tags (i. e. a "tiff-dump" utility) and don't care about the used compression.

All JPEG specific tags (that are documented in https://download.osgeo.org/libtiff/doc/TIFF6.pdf) are added. With these additions, the test images contained in https://download.osgeo.org/libtiff/pics-3.8.0.tar.gz could be read (read, NOT decompressed).