### PR TITLE
add JDK 11 to CI build

### DIFF
--- a/.github/workflows/build-test-jdk11.yml
+++ b/.github/workflows/build-test-jdk11.yml
@@ -1,0 +1,23 @@
+name: Build & Test JDK 11
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v1
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    - name: Build & Test
+      run: mvn clean package

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: Build & Test
+name: Build & Test JDK 8
 
 on:
   push:


### PR DESCRIPTION
JDK 11 works. This makes sure it stays working.

Doesn't use matrix because we don't want to upload, and also because failing builds have to be restarted everywhere if one leg of the matrix fails. That is annoying.